### PR TITLE
Configure Ruff as the main Python formatter and linter

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,0 +1,35 @@
+name: Lint
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  ruff:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check out
+      uses: actions/checkout@v4.1.1
+    - name: Cache Poetry
+      id: cache-poetry
+      uses: actions/cache@v3.3.2
+      with:
+        path: ~/.local
+        key: poetry
+    - name: Install Poetry
+      if: steps.cache-poetry.outputs.cache-hit != 'true'
+      uses: snok/install-poetry@v1.3.4
+    - name: Set up Python
+      uses: actions/setup-python@v5.0.0
+      with:
+        cache: poetry
+    - name: Install dependencies
+      run:
+        poetry install --no-root --only=lint
+    - name: Run formatter
+      run:
+        poetry run ruff format .
+    - name: Run linter
+      run:
+        poetry run ruff .

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@ __pycache__/
 
 # Distribution / packaging
 dist/
+
+# Ruff
+.ruff_cache/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -36,6 +36,14 @@ repos:
   - id: poetry-check
   - id: poetry-lock
   - id: poetry-install
+- repo: https://github.com/astral-sh/ruff-pre-commit
+  rev: "v0.1.8"
+  hooks:
+  - id: ruff
+    args:
+    - --fix
+    - --exit-non-zero-on-fix
+  - id: ruff-format
 
 # Pre-commit.ci
 # https://pre-commit.ci/#configuration

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,6 +4,7 @@
 [![Pre-commit.ci](https://results.pre-commit.ci/badge/github/paduszyk/reactor/main.svg)][pre-commit.ci]
 
 [![Poetry](https://img.shields.io/endpoint?url=https://python-poetry.org/badge/v0.json)][poetry]
+[![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)][ruff]
 
 [![Conventional Commits](https://img.shields.io/badge/Conventional%20Commits-1.0.0-fa6673.svg?logo=conventional-commits)][conventional-commits]
 [![License](https://img.shields.io/github/license/paduszyk/reactor)][license]
@@ -29,3 +30,4 @@ Released under the [MIT License][license].
 [license]: https://github.com/paduszyk/reactor/blob/main/LICENSE
 [poetry]: https://python-poetry.org
 [pre-commit.ci]: https://results.pre-commit.ci/latest/github/paduszyk/reactor/main
+[ruff]: https://github.com/astral-sh/ruff

--- a/poetry.lock
+++ b/poetry.lock
@@ -159,6 +159,32 @@ files = [
 ]
 
 [[package]]
+name = "ruff"
+version = "0.1.8"
+description = "An extremely fast Python linter and code formatter, written in Rust."
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "ruff-0.1.8-py3-none-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:7de792582f6e490ae6aef36a58d85df9f7a0cfd1b0d4fe6b4fb51803a3ac96fa"},
+    {file = "ruff-0.1.8-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:c8e3255afd186c142eef4ec400d7826134f028a85da2146102a1172ecc7c3696"},
+    {file = "ruff-0.1.8-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ff78a7583020da124dd0deb835ece1d87bb91762d40c514ee9b67a087940528b"},
+    {file = "ruff-0.1.8-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:bd8ee69b02e7bdefe1e5da2d5b6eaaddcf4f90859f00281b2333c0e3a0cc9cd6"},
+    {file = "ruff-0.1.8-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a05b0ddd7ea25495e4115a43125e8a7ebed0aa043c3d432de7e7d6e8e8cd6448"},
+    {file = "ruff-0.1.8-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:e6f08ca730f4dc1b76b473bdf30b1b37d42da379202a059eae54ec7fc1fbcfed"},
+    {file = "ruff-0.1.8-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f35960b02df6b827c1b903091bb14f4b003f6cf102705efc4ce78132a0aa5af3"},
+    {file = "ruff-0.1.8-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:7d076717c67b34c162da7c1a5bda16ffc205e0e0072c03745275e7eab888719f"},
+    {file = "ruff-0.1.8-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b6a21ab023124eafb7cef6d038f835cb1155cd5ea798edd8d9eb2f8b84be07d9"},
+    {file = "ruff-0.1.8-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:ce697c463458555027dfb194cb96d26608abab920fa85213deb5edf26e026664"},
+    {file = "ruff-0.1.8-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:db6cedd9ffed55548ab313ad718bc34582d394e27a7875b4b952c2d29c001b26"},
+    {file = "ruff-0.1.8-py3-none-musllinux_1_2_i686.whl", hash = "sha256:05ffe9dbd278965271252704eddb97b4384bf58b971054d517decfbf8c523f05"},
+    {file = "ruff-0.1.8-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:5daaeaf00ae3c1efec9742ff294b06c3a2a9db8d3db51ee4851c12ad385cda30"},
+    {file = "ruff-0.1.8-py3-none-win32.whl", hash = "sha256:e49fbdfe257fa41e5c9e13c79b9e79a23a79bd0e40b9314bc53840f520c2c0b3"},
+    {file = "ruff-0.1.8-py3-none-win_amd64.whl", hash = "sha256:f41f692f1691ad87f51708b823af4bb2c5c87c9248ddd3191c8f088e66ce590a"},
+    {file = "ruff-0.1.8-py3-none-win_arm64.whl", hash = "sha256:aa8ee4f8440023b0a6c3707f76cadce8657553655dcbb5fc9b2f9bb9bee389f6"},
+    {file = "ruff-0.1.8.tar.gz", hash = "sha256:f7ee467677467526cfe135eab86a40a0e8db43117936ac4f9b469ce9cdb3fb62"},
+]
+
+[[package]]
 name = "setuptools"
 version = "69.0.2"
 description = "Easily download, build, install, upgrade, and uninstall Python packages"
@@ -197,4 +223,4 @@ test = ["covdefaults (>=2.3)", "coverage (>=7.2.7)", "coverage-enable-subprocess
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.11"
-content-hash = "01932e97c034d08608a224580b73c05e88156f99a4fe0ac4cfc75b487e565f6f"
+content-hash = "0fad0d5b2b57d7ca3b950a79684c336ce22ac348fed9c030aff8a757b081614a"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,3 +29,39 @@ ruff = "^0.1.8"
 
 [tool.codespell]
 skip = "poetry.lock,package-lock.json"
+
+# Ruff
+# https://docs.astral.sh/ruff/configuration/
+# https://docs.astral.sh/ruff/rules/
+# https://docs.astral.sh/ruff/settings/
+
+[tool.ruff]
+target-version = "py311"
+select = [
+  "F",    # pyflakes
+  "E",    # pycodestyle (errors)
+  "W",    # pycodestyle (warnings)
+  "I",    # isort
+  "D",    # pydocstyle
+  "B",    # flake8-bugbear
+  "A",    # flake8-builtins
+  "T20",  # flake8-print
+  "PTH",  # flake8-use-pathlib
+]
+ignore = ["E501", "D1", "D205"]
+
+[tool.ruff.per-file-ignores]
+"__init__.py" = ["F401", "F403"]
+
+[tool.ruff.pydocstyle]
+convention = "google"
+
+[tool.ruff.isort]
+section-order = [
+  "future",
+  "standard-library",
+  "third-party",
+  "first-party",
+  "local-folder",
+]
+known-first-party = ["reactor"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,9 @@ python = "^3.11"
 [tool.poetry.group.dev.dependencies]
 pre-commit = "^3.6.0"
 
+[tool.poetry.group.lint.dependencies]
+ruff = "^0.1.8"
+
 # Codespell
 # https://github.com/codespell-project/codespell
 


### PR DESCRIPTION
## Linked issues

<!-- Relate this PR with an issue by using closing keywords & autolinked refs. -->

🏷️ Closes/Fixes/Resolves: N/A

## Description

<!-- Provide a detailed overview of the changes introduced by this PR. -->

[Ruff](https://docs.astral.sh/ruff/) is installed and configured as the main Python codebase formatter and linter (as a local tool, Pre-commit hook, and a job in the GitHub Actions workflow).