### PR TITLE
Set up the package CLI for adding commands

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -44,6 +44,20 @@ files = [
 ]
 
 [[package]]
+name = "click"
+version = "8.1.7"
+description = "Composable command line interface toolkit"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "click-8.1.7-py3-none-any.whl", hash = "sha256:ae74fb96c20a0277a1d615f1e4d73c8414f5a98db8b799a7931d1582f3390c28"},
+    {file = "click-8.1.7.tar.gz", hash = "sha256:ca9853ad459e787e2192211578cc907e7594e294c7ccc834310722b41b9ca6de"},
+]
+
+[package.dependencies]
+colorama = {version = "*", markers = "platform_system == \"Windows\""}
+
+[[package]]
 name = "colorama"
 version = "0.4.6"
 description = "Cross-platform colored terminal text."
@@ -633,4 +647,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.11"
-content-hash = "332bc2bc7fde70555bf64593a78ff555a9ffb3b9d14aca4e8445e6ed7d0cd1cb"
+content-hash = "f93adfb065b972b44d0064c1a02450622ae47858eb70c35953ba08ccaca15f1b"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,9 @@ packages = [
   { include = "reactor", from = "src" },
 ]
 
+[tool.poetry.scripts]
+"reactor-cli" = "reactor.cli:entry_point"
+
 [tool.poetry.dependencies]
 click = "^8.1.7"
 dj-database-url = "^2.1.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ packages = [
 ]
 
 [tool.poetry.dependencies]
+click = "^8.1.7"
 dj-database-url = "^2.1.0"
 django = { version = "^5.0", allow-prereleases = true }
 django-configurations = { version = "^2.5", extras = ["database"] }

--- a/src/reactor/__main__.py
+++ b/src/reactor/__main__.py
@@ -1,0 +1,6 @@
+from reactor.cli import entry_point
+
+__all__ = []
+
+if __name__ == "__main__":
+    entry_point()

--- a/src/reactor/cli/__init__.py
+++ b/src/reactor/cli/__init__.py
@@ -1,0 +1,1 @@
+from .main import reactor_cli as entry_point

--- a/src/reactor/cli/main.py
+++ b/src/reactor/cli/main.py
@@ -1,0 +1,46 @@
+import importlib
+
+import click
+import configurations
+from decouple import config
+from dotenv import load_dotenv
+
+from django.conf import settings
+
+__all__ = ["reactor_cli"]
+
+
+@click.group(
+    name="reactor-cli",
+    help="Run CLI utilities of the 'reactor' package.",
+)
+@click.version_option(
+    package_name="reactor",
+    message="%(version)s",
+)
+@click.pass_context
+def reactor_cli(context):
+    # Ensure that the entry point's context object is defined.
+    context.ensure_object(dict)
+
+    # Load environment variables from '.env' if the project is run locally.
+    CI = config("CI", cast=bool, default=False)
+    if not CI:
+        load_dotenv()
+
+    # Configure the project.
+    configurations.setup()
+
+    # Pass the projects' settings to the CLI context.
+    context.obj["settings"] = settings
+
+
+# Add commands defined in the '.commands' module.
+commands_module = importlib.import_module("reactor.cli.commands")
+
+for command in commands_module.__dict__.values():
+    if isinstance(command, click.Command):
+        reactor_cli.add_command(command)
+
+if __name__ == "__main__":
+    reactor_cli()


### PR DESCRIPTION
## Linked issues

<!-- Relate this PR with an issue by using closing keywords & autolinked refs. -->

🏷️ Closes/Fixes/Resolves: N/A

## Description

<!-- Provide a detailed overview of the changes introduced by this PR. -->

This installs [`click`](https://click.palletsprojects.com/) and sets up the main CLI entry point for adding commands in further development. The commands can be implemented in `reactor.cli.commands` package.

The main entry point configures the Django project. Settings can be accessed from the CLI's context object:

```python
@click.command()
@click.pass_context
def command(context):
    settings = context.obj["settings"]

    DATABASES = settings.DATABASES
```