### PR TITLE
Set up the registry for managing the project's apps and models

### DIFF
--- a/src/reactor/apps/__init__.py
+++ b/src/reactor/apps/__init__.py
@@ -1,0 +1,1 @@
+from .config import *

--- a/src/reactor/apps/__init__.py
+++ b/src/reactor/apps/__init__.py
@@ -1,2 +1,3 @@
 from .config import *
+from .decorators import *
 from .registry import *

--- a/src/reactor/apps/__init__.py
+++ b/src/reactor/apps/__init__.py
@@ -1,1 +1,2 @@
 from .config import *
+from .registry import *

--- a/src/reactor/apps/config.py
+++ b/src/reactor/apps/config.py
@@ -1,0 +1,7 @@
+from django import apps
+
+__all__ = ["AppConfig"]
+
+
+class AppConfig(apps.AppConfig):
+    """Represents a base for configuration classes of the project's apps."""

--- a/src/reactor/apps/config.py
+++ b/src/reactor/apps/config.py
@@ -1,7 +1,21 @@
 from django import apps
 
+from .decorators import on_ready
+
 __all__ = ["AppConfig"]
 
 
 class AppConfig(apps.AppConfig):
     """Represents a base for configuration classes of the project's apps."""
+
+    def ready(self):
+        super().ready()
+
+        # Call all the `@on_ready`-decorated methods.
+        for method in [
+            attr
+            for attr_name in dir(self)
+            if callable(attr := getattr(self, attr_name))
+        ]:
+            if getattr(method, on_ready.__name__, False):
+                method()

--- a/src/reactor/apps/decorators.py
+++ b/src/reactor/apps/decorators.py
@@ -1,0 +1,21 @@
+import functools
+
+__all__ = ["on_ready"]
+
+
+def on_ready(**kwargs):
+    """Return a decorator wrapping a method of an app config class such that that method
+    is marked as one that should be automatically called by the config's `ready()` hook.
+    """
+
+    def decorator(method):
+        @functools.wraps(method)
+        def wrapper(self):
+            return method(self)
+
+        # Mark the wrapper by the decorator name.
+        setattr(wrapper, on_ready.__name__, True)
+
+        return wrapper
+
+    return decorator

--- a/src/reactor/apps/registry.py
+++ b/src/reactor/apps/registry.py
@@ -1,0 +1,95 @@
+import re
+from itertools import chain
+
+from django.apps import apps as django_apps
+from django.utils.text import get_text_list
+
+__all__ = ["apps"]
+
+
+class Apps:
+    """A thin wrapper around the `django.apps.registry.Apps` for managing a subset of
+    apps installed from specified packages.
+    """
+
+    def __init__(self, *app_packages):
+        self._app_packages = app_packages
+
+        # Mapping of labels to the installed `AppConfig`.
+        self.app_configs = {}
+
+        # Populate the registry's app configs.
+        if django_apps.ready:
+            self.populate()
+
+    def populate(self):
+        """Populate the `app_configs` dict with app labels and app configs of the apps
+        installed from the registry packages.
+        """
+        app_config_name_pattern = (
+            rf"^({'|'.join(map(re.escape, self._app_packages))})(?:\.\w+)*$"
+        )
+        self.app_configs = {
+            app_config.label: app_config
+            for app_config in django_apps.get_app_configs()
+            if re.match(app_config_name_pattern, app_config.name)
+        }
+
+    def get_app_configs(self):
+        """Return an iterable of all the registered app configs."""
+        return self.app_configs.values()
+
+    def get_app_config(self, app_label):
+        """Return an app config for the app label given or raise `LookupError` if no
+        app with that label exists.
+        """
+        try:
+            return self.app_configs[app_label]
+        except KeyError as exc_info:
+            raise LookupError(
+                f"no installed app with label {app_label!r}"
+            ) from exc_info
+
+    def get_models(self):
+        """Return an iterable of all the models defined in the registry's apps."""
+        return chain(
+            *[app_config.get_models() for app_config in self.get_app_configs()]
+        )
+
+    def get_model(self, model_name):
+        """Return a model based on its (case insensitive) name.
+
+        Compared to the "base" method of `django.apps.registry.apps`, a model can
+        be returned based on its `model_name` meta-attribute only (the "base" method
+        requires either a `app_label.model_name` label or `app_label` and `model_name`
+        separately). If multiple models with the same names are found, a `ValueError`
+        is raised.
+        """
+        if "." in model_name:
+            app_label, model_name = model_name.split(".")
+
+            return self.get_app_config(app_label).get_model(model_name)
+
+        model_name = model_name.lower()
+        if not (
+            models := [
+                model
+                for model in self.get_models()
+                if model._meta.model_name == model_name
+            ]
+        ):
+            raise LookupError(f"no installed model with name {model_name!r}")
+
+        if len(models) > 1:
+            model_labels = get_text_list(
+                [f"{model._meta.label!r}" for model in models], last_word="or"
+            )
+            raise ValueError(
+                f"a model with name {model_name!r} found in multiple apps; use "
+                f"{model_labels} to refer to a specific model"
+            )
+
+        return models[0]
+
+
+apps = Apps("reactor")

--- a/tests/apps/test_config.py
+++ b/tests/apps/test_config.py
@@ -1,0 +1,39 @@
+import importlib
+
+import pytest
+
+from reactor import apps
+from reactor.apps.decorators import on_ready
+
+
+@pytest.fixture()
+def app_config():
+    class AppConfig(apps.AppConfig):
+        def regular_method(self):
+            pass
+
+        @on_ready()
+        def on_ready_method(self):
+            pass
+
+    return AppConfig(__name__, importlib.import_module(__name__))
+
+
+def test_app_config_ready_calls_on_ready_method(mocker, app_config):
+    on_ready_method = mocker.patch.object(
+        app_config, "on_ready_method", spec=app_config.on_ready_method
+    )
+
+    app_config.ready()
+
+    on_ready_method.assert_called()
+
+
+def test_app_config_ready_does_not_call_regular_method(mocker, app_config):
+    regular_method = mocker.patch.object(
+        app_config, "regular_method", spec=app_config.regular_method
+    )
+
+    app_config.ready()
+
+    regular_method.assert_not_called()

--- a/tests/apps/test_decorators.py
+++ b/tests/apps/test_decorators.py
@@ -1,0 +1,16 @@
+from reactor.apps.decorators import on_ready
+
+
+def test_on_ready_method_has_on_ready_attribute(mocker):
+    class AppConfig(mocker.Mock):
+        def regular_method(self):
+            pass
+
+        @on_ready()
+        def on_ready_method(self):
+            pass
+
+    app_config = AppConfig()
+
+    assert not hasattr(app_config.regular_method, "on_ready")
+    assert hasattr(app_config.on_ready_method, "on_ready")

--- a/tests/apps/test_registry.py
+++ b/tests/apps/test_registry.py
@@ -1,0 +1,185 @@
+import pytest
+
+from django.apps import apps as django_apps
+
+from reactor.apps.registry import Apps
+
+
+@pytest.fixture(autouse=True)
+def _django_apps_as_ready(mocker):
+    mocker.patch.object(django_apps, "ready", True)
+
+
+@pytest.fixture()
+def make_app_config(mocker):
+    def _make_app_config(name):
+        app_config = mocker.Mock()
+
+        app_config.name = name
+        app_config.label = app_config.name.rpartition(".")[2]
+
+        return app_config
+
+    return _make_app_config
+
+
+@pytest.fixture()
+def make_model(mocker):
+    def _make_model(app_label, model_name):
+        model = mocker.Mock()
+
+        model._meta = mocker.Mock(
+            app_label=app_label,
+            model_name=model_name.lower(),
+            label=f"{app_label}.{model_name}",
+        )
+
+        return model
+
+    return _make_model
+
+
+def test_registry_is_populated_when_django_apps_ready(mocker):
+    apps_populate = mocker.patch.object(Apps, "populate")
+
+    Apps()
+
+    apps_populate.assert_called()
+
+
+def test_registry_is_not_populated_when_django_apps_not_ready(mocker):
+    mocker.patch.object(django_apps, "ready", False)
+
+    apps_populate = mocker.patch.object(Apps, "populate")
+
+    Apps()
+
+    apps_populate.assert_not_called()
+
+
+def test_registry_contains_only_apps_installed_from_specified_packages(mocker, make_app_config):  # fmt: skip
+    package_1_app_config = make_app_config("package_1.package_1_app")
+    package_2_app_config = make_app_config("package_2.package_2_app")
+    package_3_app_config = make_app_config("package_3.package_3_app")
+
+    mocker.patch.object(
+        django_apps,
+        "app_configs",
+        {
+            "package_1_app": package_1_app_config,
+            "package_2_app": package_2_app_config,
+            "package_3_app": package_3_app_config,
+        },
+    )
+
+    apps = Apps("package_1", "package_2")
+
+    assert apps.app_configs == {
+        "package_1_app": package_1_app_config,
+        "package_2_app": package_2_app_config,
+    }
+
+
+def test_registry_get_app_configs_returns_all_registry_apps(mocker):
+    apps = Apps()
+
+    mocker.patch.object(apps, "app_configs")
+
+    app_configs = apps.get_app_configs()
+
+    assert app_configs == apps.app_configs.values()
+
+
+def test_registry_get_app_config_returns_app_config_from_valid_app_label(mocker):
+    apps = Apps()
+
+    mocker.patch.object(apps, "app_configs", {"package_app": mocker.Mock()})
+
+    app_config = apps.get_app_config("package_app")
+
+    assert app_config == apps.app_configs["package_app"]
+
+
+def test_registry_get_app_config_raises_lookup_error_from_nonexistent_app_label(mocker):
+    apps = Apps()
+
+    mocker.patch.object(apps, "app_configs", {"package_app": mocker.Mock()})
+
+    with pytest.raises(
+        LookupError, match="no installed app with label 'nonexistent_app'"
+    ):
+        apps.get_app_config("nonexistent_app")
+
+
+def test_registry_get_models_returns_models_from_all_registry_app_configs(mocker):
+    app_config_1 = mocker.Mock()
+    app_config_1.get_models.return_value = [model_1 := mocker.Mock()]
+
+    app_config_2 = mocker.Mock()
+    app_config_2.get_models.return_value = [
+        model_2 := mocker.Mock(),
+        model_3 := mocker.Mock(),
+    ]
+
+    apps = Apps()
+
+    mocker.patch.object(
+        apps, "get_app_configs", return_value=[app_config_1, app_config_2]
+    )
+
+    models = apps.get_models()
+
+    assert list(models) == [model_1, model_2, model_3]
+
+
+def test_registry_get_model_returns_model_from_valid_model_name(mocker):
+    model = mocker.Mock()
+
+    class AppConfig(mocker.Mock):
+        models = {"model": model}
+
+        def get_model(self, model_name):
+            return self.models[model_name]
+
+    apps = Apps()
+
+    mocker.patch.object(apps, "get_app_config", return_value=AppConfig())
+
+    assert apps.get_model("package_app.model") == model
+
+
+def test_registry_get_model_returns_model_from_unique_model_name(mocker, make_model):
+    model = make_model("package_app", "Model")
+
+    apps = Apps()
+
+    mocker.patch.object(apps, "get_models", return_value=[model])
+
+    assert apps.get_model("model") == model
+
+
+def test_registry_get_model_raises_lookup_error_from_nonexistent_model_name(mocker):
+    apps = Apps()
+
+    mocker.patch.object(apps, "get_models", return_value=[])
+
+    with pytest.raises(LookupError, match="no installed model with name 'model'"):
+        apps.get_model("model")
+
+
+def test_registry_get_model_raises_value_error_from_nonunique_model_name(mocker, make_model):  # fmt: skip
+    model_1 = make_model("package_app_1", "Model")
+    model_2 = make_model("package_app_2", "Model")
+
+    apps = Apps()
+
+    mocker.patch.object(apps, "get_models", return_value=[model_1, model_2])
+
+    with pytest.raises(
+        ValueError,
+        match=(
+            "a model with name 'model' found in multiple apps; use 'package_app_1.Model' "
+            "or 'package_app_2.Model' to refer to a specific model"
+        ),
+    ):
+        apps.get_model("model")


### PR DESCRIPTION
## Linked issues

<!-- Relate this PR with an issue by using closing keywords & autolinked refs. -->

🏷️ Closes/Fixes/Resolves: N/A

## Description

<!-- Provide a detailed overview of the changes introduced by this PR. -->

This "overrides" `django.apps` module functionalities to provide more convenient way for the project's apps and models management. In particular:

* `django.apps.config.AppConfig` is overridden by `reactor.apps.config.AppConfig`; all the project's apps should be build on the latter;
* `django.apps.registry.apps` (usually imported directly from `django.apps`) is replaced by `reactor.registry.apps`, which enable to access only the apps defined in the `reactor` package as well as models of those apps.

The custom `AppConfig` method overrides `ready()` hook, so that it automatically calls methods decorated by `@on_ready()` (also a part of this PR).

Unit tests cover all the changes.