### PR TITLE
Set up Dependabot

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,47 @@
+# Dependabot
+# https://docs.github.com/en/code-security/dependabot/dependabot-version-updates
+
+version: 2
+
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    allow:
+      - dependency-type: "all"
+    pull-request-branch-name:
+      separator: "-"
+    commit-message:
+      prefix: "build"
+      prefix-development: "build"
+      include: "scope"
+    labels:
+      - "dependencies"
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    allow:
+      - dependency-type: "all"
+    pull-request-branch-name:
+      separator: "-"
+    commit-message:
+      prefix: "build"
+      prefix-development: "build"
+      include: "scope"
+    labels:
+      - "dependencies"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    allow:
+      - dependency-type: "all"
+    pull-request-branch-name:
+      separator: "-"
+    commit-message:
+      prefix: "ci"
+      include: "scope"
+    labels:
+      - "dependencies"

--- a/.github/workflows/commitlint.yaml
+++ b/.github/workflows/commitlint.yaml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   commitlint:
+    if: ${{ github.actor != 'dependabot[bot]' }}
     runs-on: ubuntu-latest
     steps:
       - name: Check out

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,5 +1,7 @@
 # reactor
 
+[![Dependabot](https://img.shields.io/badge/dependabot-active-brightgreen?logo=dependabot)][dependabot]
+
 [![Poetry](https://img.shields.io/endpoint?url=https://python-poetry.org/badge/v0.json)][poetry]
 [![Prettier](https://img.shields.io/badge/code%20style-prettier-1E2B33?logo=Prettier)][prettier]
 
@@ -22,6 +24,7 @@ Created and maintained by Kamil Paduszyński ([@paduszyk][github-paduszyk]).
 Released under the [MIT License][license].
 
 [conventional-commits]: https://conventionalcommits.org
+[dependabot]: https://github.com/paduszyk/reactor/blob/main/.github/dependabot.yaml
 [github-paduszyk]: https://github.com/paduszyk
 [license]: https://github.com/paduszyk/reactor/blob/main/LICENSE
 [poetry]: https://python-poetry.org


### PR DESCRIPTION
## Description

[Dependabot](https://docs.github.com/en/code-security/dependabot) is set up to monitor and update Python, Node, and GitHub Actions dependencies.
