### PR TITLE
Set up the Ruff's formatter and linter

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -27,3 +27,27 @@ jobs:
           config: ".markdownlint.jsonc"
           globs: |
             docs/*.md
+  ruff:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out
+        uses: actions/checkout@v4.1.1
+      - name: Cache Poetry
+        id: cache-poetry
+        uses: actions/cache@v3.3.2
+        with:
+          path: ~/.local
+          key: poetry
+      - name: Install Poetry
+        if: steps.cache-poetry.outputs.cache-hit != 'true'
+        uses: snok/install-poetry@v1.3.4
+      - name: Set up Python
+        uses: actions/setup-python@v5.0.0
+        with:
+          cache: poetry
+      - name: Install linters
+        run: poetry install --no-root --only=lint
+      - name: Format Python with Ruff
+        run: poetry run ruff format .
+      - name: Lint Python with Ruff
+        run: poetry run ruff .

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@ __pycache__/
 
 # Distribution and packaging
 dist/
+
+# Ruff
+.ruff_cache/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -39,6 +39,12 @@ repos:
         args: [--no-interaction]
       - id: poetry-lock
         args: [--no-update, --no-interaction]
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: "v0.1.11"
+    hooks:
+      - id: ruff
+        args: [--fix, --exit-non-zero-on-fix]
+      - id: ruff-format
 
 # Pre-commit.ci
 # https://pre-commit.ci/#configuration

--- a/docs/README.md
+++ b/docs/README.md
@@ -5,6 +5,7 @@
 
 [![Poetry](https://img.shields.io/endpoint?url=https://python-poetry.org/badge/v0.json)][poetry]
 [![Prettier](https://img.shields.io/badge/code%20style-prettier-1E2B33?logo=Prettier)][prettier]
+[![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)][ruff]
 
 [![Conventional Commits](https://img.shields.io/badge/Conventional%20Commits-1.0.0-fa6673.svg?logo=conventional-commits)][conventional-commits]
 [![License](https://img.shields.io/github/license/paduszyk/reactor)][license]
@@ -31,3 +32,4 @@ Released under the [MIT License][license].
 [poetry]: https://python-poetry.org
 [pre-commit.ci]: https://results.pre-commit.ci/latest/github/paduszyk/reactor/main
 [prettier]: https://prettier.io
+[ruff]: https://github.com/astral-sh/ruff

--- a/poetry.lock
+++ b/poetry.lock
@@ -159,6 +159,32 @@ files = [
 ]
 
 [[package]]
+name = "ruff"
+version = "0.1.11"
+description = "An extremely fast Python linter and code formatter, written in Rust."
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "ruff-0.1.11-py3-none-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:a7f772696b4cdc0a3b2e527fc3c7ccc41cdcb98f5c80fdd4f2b8c50eb1458196"},
+    {file = "ruff-0.1.11-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:934832f6ed9b34a7d5feea58972635c2039c7a3b434fe5ba2ce015064cb6e955"},
+    {file = "ruff-0.1.11-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ea0d3e950e394c4b332bcdd112aa566010a9f9c95814844a7468325290aabfd9"},
+    {file = "ruff-0.1.11-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:9bd4025b9c5b429a48280785a2b71d479798a69f5c2919e7d274c5f4b32c3607"},
+    {file = "ruff-0.1.11-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:e1ad00662305dcb1e987f5ec214d31f7d6a062cae3e74c1cbccef15afd96611d"},
+    {file = "ruff-0.1.11-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:4b077ce83f47dd6bea1991af08b140e8b8339f0ba8cb9b7a484c30ebab18a23f"},
+    {file = "ruff-0.1.11-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:c4a88efecec23c37b11076fe676e15c6cdb1271a38f2b415e381e87fe4517f18"},
+    {file = "ruff-0.1.11-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:5b25093dad3b055667730a9b491129c42d45e11cdb7043b702e97125bcec48a1"},
+    {file = "ruff-0.1.11-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:231d8fb11b2cc7c0366a326a66dafc6ad449d7fcdbc268497ee47e1334f66f77"},
+    {file = "ruff-0.1.11-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:09c415716884950080921dd6237767e52e227e397e2008e2bed410117679975b"},
+    {file = "ruff-0.1.11-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:0f58948c6d212a6b8d41cd59e349751018797ce1727f961c2fa755ad6208ba45"},
+    {file = "ruff-0.1.11-py3-none-musllinux_1_2_i686.whl", hash = "sha256:190a566c8f766c37074d99640cd9ca3da11d8deae2deae7c9505e68a4a30f740"},
+    {file = "ruff-0.1.11-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:6464289bd67b2344d2a5d9158d5eb81025258f169e69a46b741b396ffb0cda95"},
+    {file = "ruff-0.1.11-py3-none-win32.whl", hash = "sha256:9b8f397902f92bc2e70fb6bebfa2139008dc72ae5177e66c383fa5426cb0bf2c"},
+    {file = "ruff-0.1.11-py3-none-win_amd64.whl", hash = "sha256:eb85ee287b11f901037a6683b2374bb0ec82928c5cbc984f575d0437979c521a"},
+    {file = "ruff-0.1.11-py3-none-win_arm64.whl", hash = "sha256:97ce4d752f964ba559c7023a86e5f8e97f026d511e48013987623915431c7ea9"},
+    {file = "ruff-0.1.11.tar.gz", hash = "sha256:f9d4d88cb6eeb4dfe20f9f0519bd2eaba8119bde87c3d5065c541dbae2b5a2cb"},
+]
+
+[[package]]
 name = "setuptools"
 version = "69.0.3"
 description = "Easily download, build, install, upgrade, and uninstall Python packages"
@@ -197,4 +223,4 @@ test = ["covdefaults (>=2.3)", "coverage (>=7.2.7)", "coverage-enable-subprocess
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.11"
-content-hash = "01932e97c034d08608a224580b73c05e88156f99a4fe0ac4cfc75b487e565f6f"
+content-hash = "13b9a0a00ec1950a29d4d7dbfb70c8c201a2a12cdfa3bdd12b68c52fb5174857"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,3 +20,6 @@ python = "^3.11"
 
 [tool.poetry.group.dev.dependencies]
 pre-commit = "^3.6.0"
+
+[tool.poetry.group.lint.dependencies]
+ruff = "^0.1.11"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,3 +23,39 @@ pre-commit = "^3.6.0"
 
 [tool.poetry.group.lint.dependencies]
 ruff = "^0.1.11"
+
+# Ruff
+# https://docs.astral.sh/ruff/configuration/
+# https://docs.astral.sh/ruff/rules/
+# https://docs.astral.sh/ruff/settings/
+
+[tool.ruff]
+target-version = "py311"
+select = [
+  "F",
+  "E",
+  "W",
+  "I",
+  "D",
+]
+ignore = [
+  "E501",
+  "D1",
+  "D205",
+]
+
+[tool.ruff.per-file-ignores]
+"__init__.py" = ["F401", "F403"]
+
+[tool.ruff.pydocstyle]
+convention = "google"
+
+[tool.ruff.isort]
+section-order = [
+  "future",
+  "standard-library",
+  "third-party",
+  "first-party",
+  "local-folder",
+]
+known-first-party = ["reactor"]


### PR DESCRIPTION
## Description

[Ruff](https://docs.astral.sh/ruff/) is installed and configured as the main Python codebase formatter and linter (as a local tool, Pre-commit hook, and a job in the GitHub Actions workflow).
