### PR TITLE
Start and install the "contrib" apps

### DIFF
--- a/apps/contributions/__init__.py
+++ b/apps/contributions/__init__.py
@@ -1,0 +1,3 @@
+from . import settings
+
+__all__ = []

--- a/apps/contributions/apps.py
+++ b/apps/contributions/apps.py
@@ -1,0 +1,12 @@
+from django.utils.translation import gettext_lazy as _
+
+from reactor import apps
+
+__all__ = ["ContributionsConfig"]
+
+
+class ContributionsConfig(apps.AppConfig):
+    """Represents the `contributions` app and its configuration."""
+
+    name = "contributions"
+    verbose_name = _("Contributions")

--- a/apps/contributions/settings.py
+++ b/apps/contributions/settings.py
@@ -1,0 +1,7 @@
+from appconf import AppConf
+
+__all__ = ["ContributionsConf"]
+
+
+class ContributionsConf(AppConf):
+    """Encapsulates settings specific to the `contributions` app."""

--- a/apps/contributions/urls.py
+++ b/apps/contributions/urls.py
@@ -1,0 +1,5 @@
+__all__ = ["app_name", "urlpatterns"]
+
+app_name = "contributions"
+
+urlpatterns = []

--- a/apps/human_resources/__init__.py
+++ b/apps/human_resources/__init__.py
@@ -1,0 +1,3 @@
+from . import settings
+
+__all__ = []

--- a/apps/human_resources/apps.py
+++ b/apps/human_resources/apps.py
@@ -1,0 +1,12 @@
+from django.utils.translation import gettext_lazy as _
+
+from reactor import apps
+
+__all__ = ["HumanResourcesConfig"]
+
+
+class HumanResourcesConfig(apps.AppConfig):
+    """Represents the `human_resources` app and its configuration."""
+
+    name = "human_resources"
+    verbose_name = _("Human Resources")

--- a/apps/human_resources/settings.py
+++ b/apps/human_resources/settings.py
@@ -1,0 +1,7 @@
+from appconf import AppConf
+
+__all__ = ["HumanResourcesConf"]
+
+
+class HumanResourcesConf(AppConf):
+    """Encapsulates settings specific to the `human_resources` app."""

--- a/apps/human_resources/urls.py
+++ b/apps/human_resources/urls.py
@@ -1,0 +1,5 @@
+__all__ = ["app_name", "urlpatterns"]
+
+app_name = "human_resources"
+
+urlpatterns = []

--- a/apps/publishing_media/__init__.py
+++ b/apps/publishing_media/__init__.py
@@ -1,0 +1,3 @@
+from . import settings
+
+__all__ = []

--- a/apps/publishing_media/apps.py
+++ b/apps/publishing_media/apps.py
@@ -1,0 +1,12 @@
+from django.utils.translation import gettext_lazy as _
+
+from reactor import apps
+
+__all__ = ["PublishingMedia"]
+
+
+class PublishingMedia(apps.AppConfig):
+    """Represents the `publishing_media` app and its configuration."""
+
+    name = "publishing_media"
+    verbose_name = _("Publishing Media")

--- a/apps/publishing_media/settings.py
+++ b/apps/publishing_media/settings.py
@@ -1,0 +1,7 @@
+from appconf import AppConf
+
+__all__ = ["PublishingMediaConf"]
+
+
+class PublishingMediaConf(AppConf):
+    """Encapsulates settings specific to the `publishing_media` app."""

--- a/apps/publishing_media/urls.py
+++ b/apps/publishing_media/urls.py
@@ -1,0 +1,5 @@
+__all__ = ["app_name", "urlpatterns"]
+
+app_name = "publishing_media"
+
+urlpatterns = []

--- a/apps/science/__init__.py
+++ b/apps/science/__init__.py
@@ -1,0 +1,3 @@
+from . import settings
+
+__all__ = []

--- a/apps/science/apps.py
+++ b/apps/science/apps.py
@@ -1,0 +1,12 @@
+from django.utils.translation import gettext_lazy as _
+
+from reactor import apps
+
+__all__ = ["ScienceConfig"]
+
+
+class ScienceConfig(apps.AppConfig):
+    """Represents the `science` app and its configuration."""
+
+    name = "science"
+    verbose_name = _("Science")

--- a/apps/science/settings.py
+++ b/apps/science/settings.py
@@ -1,0 +1,7 @@
+from appconf import AppConf
+
+__all__ = ["ScienceConf"]
+
+
+class ScienceConf(AppConf):
+    """Encapsulates settings specific to the `science` app."""

--- a/apps/science/urls.py
+++ b/apps/science/urls.py
@@ -1,0 +1,5 @@
+__all__ = ["app_name", "urlpatterns"]
+
+app_name = "science"
+
+urlpatterns = []

--- a/apps/units/__init__.py
+++ b/apps/units/__init__.py
@@ -1,0 +1,3 @@
+from . import settings
+
+__all__ = []

--- a/apps/units/apps.py
+++ b/apps/units/apps.py
@@ -1,0 +1,12 @@
+from django.utils.translation import gettext_lazy as _
+
+from reactor import apps
+
+__all__ = ["UnitsConfig"]
+
+
+class UnitsConfig(apps.AppConfig):
+    """Represents the `units` app and its configuration."""
+
+    name = "units"
+    verbose_name = _("Units")

--- a/apps/units/settings.py
+++ b/apps/units/settings.py
@@ -1,0 +1,7 @@
+from appconf import AppConf
+
+__all__ = ["UnitsConf"]
+
+
+class UnitsConf(AppConf):
+    """Encapsulates settings specific to the `units` app."""

--- a/apps/units/urls.py
+++ b/apps/units/urls.py
@@ -1,0 +1,5 @@
+__all__ = ["app_name", "urlpatterns"]
+
+app_name = "units"
+
+urlpatterns = []

--- a/apps/works/__init__.py
+++ b/apps/works/__init__.py
@@ -1,0 +1,3 @@
+from . import settings
+
+__all__ = []

--- a/apps/works/apps.py
+++ b/apps/works/apps.py
@@ -1,0 +1,12 @@
+from django.utils.translation import gettext_lazy as _
+
+from reactor import apps
+
+__all__ = ["WorksConfig"]
+
+
+class WorksConfig(apps.AppConfig):
+    """Represents the `works` app and its configuration."""
+
+    name = "works"
+    verbose_name = _("Works")

--- a/apps/works/settings.py
+++ b/apps/works/settings.py
@@ -1,0 +1,7 @@
+from appconf import AppConf
+
+__all__ = ["WorksConf"]
+
+
+class WorksConf(AppConf):
+    """Encapsulates settings specific to the `works` app."""

--- a/apps/works/urls.py
+++ b/apps/works/urls.py
@@ -1,0 +1,5 @@
+__all__ = ["app_name", "urlpatterns"]
+
+app_name = "works"
+
+urlpatterns = []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,9 +65,18 @@ section-order = [
   "third-party",
   "django",
   "first-party",
+  "apps",
   "local-folder",
 ]
 known-first-party = ["reactor"]
 
 [tool.ruff.isort.sections]
+"apps" = [
+  "contributions",
+  "human_resources",
+  "publishing_media",
+  "science",
+  "units",
+  "works",
+]
 "django" = ["django"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ readme = "docs/README.md"
 repository = "https://github.com/paduszyk/reactor"
 packages = [
   { include = "reactor" },
+  { include = "**/*", from = "apps" },
 ]
 
 [tool.poetry.dependencies]

--- a/reactor/settings.py
+++ b/reactor/settings.py
@@ -42,6 +42,14 @@ class Common(Configuration):
         # Project-level apps
         "reactor.core",
         "reactor.db",
+        #
+        # Project-contrib apps
+        "contributions",
+        "human_resources",
+        "publishing_media",
+        "science",
+        "units",
+        "works",
     ]
 
     MIDDLEWARE = [

--- a/reactor/urls.py
+++ b/reactor/urls.py
@@ -18,7 +18,14 @@ project_urls = [
 
 # Includes from the project's contrib apps
 
-contrib_app_urls = []
+contrib_app_urls = [
+    path("", include("contributions.urls")),
+    path("", include("human_resources.urls")),
+    path("", include("publishing_media.urls")),
+    path("", include("science.urls")),
+    path("", include("units.urls")),
+    path("", include("works.urls")),
+]
 
 
 # Admin site


### PR DESCRIPTION
## Description

This adds the packages representing the "contrib"[^1] (i.e., data model) apps and installs them in the project.

All the apps are collected in the `apps/` dir of the project's root.

[^1]: The terminology is inspired by the name of the package that provides the basic Django apps (`django.contrib`).
