### PR TITLE
ci(codecov): set up coverage report uploads to Codecov.io

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,11 @@
+codecov:
+  branch: main
+
+coverage:
+  status:
+    project:
+      default:
+        informational: true
+    patch:
+      default:
+        informational: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,4 +96,25 @@ jobs:
       - name: Install depenedencies
         run: poetry install --with test --extras ${{ matrix.django-database-engine }}
       - name: Run tests
-        run: poetry run pytest
+        run: poetry run pytest --cov-report=xml:coverage.xml
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4.3.1
+        with:
+          name: coverage-${{ matrix.django-database-engine }}
+          path: "./coverage.xml"
+          if-no-files-found: error
+  codecov:
+    needs: tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4.1.2
+      - name: Download artifacts
+        uses: actions/download-artifact@v4.1.4
+      - name: Upload coverage reports to Codecov.io
+        uses: codecov/codecov-action@v4.1.1
+        with:
+          fail_ci_if_error: false
+          slug: ${{ github.repository }}
+          token: ${{ secrets.CODECOV_TOKEN }}
+          verbose: true

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,7 @@
 # reactor
 
 [![CI](https://img.shields.io/github/actions/workflow/status/paduszyk/reactor/ci.yml?label=CI&logo=github)][ci]
+[![Codecov.io](https://img.shields.io/codecov/c/github/paduszyk/reactor?logo=codecov)][codecov.io]
 
 [![Django](https://img.shields.io/badge/Django-092e20?&logo=django&logoColor=white)][django]
 [![Poetry](https://img.shields.io/endpoint?url=https://python-poetry.org/badge/v0.json)][poetry]
@@ -25,6 +26,7 @@ Created and maintained by [@paduszyk][paduszyk].
 Released under the [BSD 3-Clause License][license].
 
 [ci]: https://github.com/paduszyk/reactor/actions/workflows/ci.yml
+[codecov.io]: https://app.codecov.io/gh/paduszyk/reactor
 [conventional-commits]: https://conventionalcommits.org
 [django]: https://www.djangoproject.com
 [license]: https://github.com/paduszyk/reactor/blob/main/LICENSE


### PR DESCRIPTION
Uploading the coverage reports to [Codecov.io](https://codecov.io) is set up to follow the successful run of the `tests` job (#7) in the main CI workflow.