### PR TITLE
build(deps-dev): set up the `django-schema-graph` app

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -15,6 +15,48 @@ files = [
 tests = ["mypy (>=0.800)", "pytest", "pytest-asyncio"]
 
 [[package]]
+name = "attrs"
+version = "23.2.0"
+description = "Classes Without Boilerplate"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "attrs-23.2.0-py3-none-any.whl", hash = "sha256:99b87a485a5820b23b879f04c2305b44b951b502fd64be915879d77a7e8fc6f1"},
+    {file = "attrs-23.2.0.tar.gz", hash = "sha256:935dc3b529c262f6cf76e50877d35a4bd3c1de194fd41f47a2b7ae8f19971f30"},
+]
+
+[package.extras]
+cov = ["attrs[tests]", "coverage[toml] (>=5.3)"]
+dev = ["attrs[tests]", "pre-commit"]
+docs = ["furo", "myst-parser", "sphinx", "sphinx-notfound-page", "sphinxcontrib-towncrier", "towncrier", "zope-interface"]
+tests = ["attrs[tests-no-zope]", "zope-interface"]
+tests-mypy = ["mypy (>=1.6)", "pytest-mypy-plugins"]
+tests-no-zope = ["attrs[tests-mypy]", "cloudpickle", "hypothesis", "pympler", "pytest (>=4.3.0)", "pytest-xdist[psutil]"]
+
+[[package]]
+name = "cattrs"
+version = "23.2.3"
+description = "Composable complex class support for attrs and dataclasses."
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "cattrs-23.2.3-py3-none-any.whl", hash = "sha256:0341994d94971052e9ee70662542699a3162ea1e0c62f7ce1b4a57f563685108"},
+    {file = "cattrs-23.2.3.tar.gz", hash = "sha256:a934090d95abaa9e911dac357e3a8699e0b4b14f8529bcc7d2b1ad9d51672b9f"},
+]
+
+[package.dependencies]
+attrs = ">=23.1.0"
+
+[package.extras]
+bson = ["pymongo (>=4.4.0)"]
+cbor2 = ["cbor2 (>=5.4.6)"]
+msgpack = ["msgpack (>=1.0.5)"]
+orjson = ["orjson (>=3.9.2)"]
+pyyaml = ["pyyaml (>=6.0)"]
+tomlkit = ["tomlkit (>=0.11.8)"]
+ujson = ["ujson (>=5.7.0)"]
+
+[[package]]
 name = "cfgv"
 version = "3.4.0"
 description = "Validate configuration and produce human readable error messages."
@@ -167,6 +209,21 @@ database = ["dj-database-url"]
 email = ["dj-email-url"]
 search = ["dj-search-url"]
 testing = ["dj-database-url", "dj-email-url", "dj-search-url", "django-cache-url (>=1.0.0)"]
+
+[[package]]
+name = "django-schema-graph"
+version = "3.1.0"
+description = "An interactive graph of your Django model structure."
+optional = false
+python-versions = ">=3.10"
+files = [
+    {file = "django_schema_graph-3.1.0-py3-none-any.whl", hash = "sha256:b240e308414018409e1588ca65a0b104f19b3829303e39071e9aa85b86317d3d"},
+    {file = "django_schema_graph-3.1.0.tar.gz", hash = "sha256:d8ef410ccd0db0fce5942a35beaa6badbca76ddce3430d9c58ac1549ad4390ab"},
+]
+
+[package.dependencies]
+attrs = ">=21.4.0"
+cattrs = ">=22.1.0"
 
 [[package]]
 name = "filelock"
@@ -553,4 +610,4 @@ sqlite = []
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.11"
-content-hash = "809bd64ef3a5e0e89c708c631ee24f6d98ab6fc859194778fde2f8e14cd2fbe9"
+content-hash = "14f23af634306415255a7e42f8b7ad877a70fa05b67ff554173d98788f97fa19"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ django = "^5.0.3"
 django-configurations = { version = "^2.5.1", extras = ["database"] }
 
 [tool.poetry.group.dev.dependencies]
+django-schema-graph = "^3.1.0"
 pre-commit = "^3.7.0"
 
 [tool.poetry.group.lint.dependencies]

--- a/src/reactor/conf/settings.py
+++ b/src/reactor/conf/settings.py
@@ -229,6 +229,20 @@ class Local(Debug):
 
     DOTENV = Debug.BASE_DIR / ".env"
 
+    @property
+    def THIRD_PARTY_APPS(self):
+        return super().THIRD_PARTY_APPS + [
+            "schema_graph",
+        ]
+
+    @classmethod
+    def get_urlpatterns(cls):
+        from schema_graph.views import Schema
+
+        return super().get_urlpatterns() + [
+            path("schema/", Schema.as_view()),
+        ]
+
 
 class CI(Debug):
     """Represents settings specific to continuous integration environments."""


### PR DESCRIPTION
This installs the [`django-schema-graph`](https://github.com/meshy/django-schema-graph) app.

The app is added to the group of development dependencies. It will assist in the project's database schema setup process.