### PR TITLE
ci: adopt semantic PR titles

### DIFF
--- a/.github/workflows/semantic-pr-title.yml
+++ b/.github/workflows/semantic-pr-title.yml
@@ -1,0 +1,18 @@
+name: Semantic PR Title
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - synchronize
+
+jobs:
+  semantic-pr-title:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    steps:
+      - uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,5 +1,7 @@
 # reactor
 
+[![Conventional Commits](https://img.shields.io/badge/Conventional_Commits-1.0.0-fa6673?&style=flat-square&logo=conventional-commits)][conventional-commits]
+
 ## Authors
 
 Created and maintained by Kamil Paduszyński ([@paduszyk][paduszyk]).
@@ -8,5 +10,6 @@ Created and maintained by Kamil Paduszyński ([@paduszyk][paduszyk]).
 
 Released under the [BSD 3-Clause License][license].
 
+[conventional-commits]: https://www.conventionalcommits.org/en/v1.0.0/
 [license]: https://github.com/paduszyk/reactor/blob/main/LICENSE
 [paduszyk]: https://github.com/paduszyk


### PR DESCRIPTION
This enforces the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format of pull request titles via [@amannn/action-semantic-pull-request](https://github.com/amannn/action-semantic-pull-request).