### PR TITLE
chore: set up Prettier

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,18 @@
+name: Lint
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  prettier:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: creyD/prettier_action@v4.3
+        with:
+          prettier_options: --check .

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# Node
+node_modules/

--- a/.prettierrc.yaml
+++ b/.prettierrc.yaml
@@ -1,0 +1,4 @@
+# Prettier
+# https://prettier.io
+
+overrides: []

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,5 +1,6 @@
 # reactor
 
+[![Prettier](https://img.shields.io/badge/code_style-prettier-1e2b33?style=flat-square&logo=prettier)][prettier]
 [![Conventional Commits](https://img.shields.io/badge/Conventional_Commits-1.0.0-fa6673?&style=flat-square&logo=conventional-commits)][conventional-commits]
 
 ## Authors
@@ -13,3 +14,4 @@ Released under the [BSD 3-Clause License][license].
 [conventional-commits]: https://www.conventionalcommits.org/en/v1.0.0/
 [license]: https://github.com/paduszyk/reactor/blob/main/LICENSE
 [paduszyk]: https://github.com/paduszyk
+[prettier]: https://prettier.io

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,28 @@
+{
+  "name": "reactor",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "devDependencies": {
+        "prettier": "^3.3.2"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.3.2.tgz",
+      "integrity": "sha512-rAVeHYMcv8ATV5d508CFdn+8/pHPpXeIid1DdrPwXnaAdH7cqjVbpJaT5eq4yRAFU/lsbwYwSF/n5iNrdJHPQA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,5 @@
+{
+  "devDependencies": {
+    "prettier": "^3.3.2"
+  }
+}


### PR DESCRIPTION
This sets up [Prettier](https://prettier.io/) as the default formatter for non-Python assets.