### PR TITLE
ci: upload coverage reports to Codecov

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,14 @@
+# Codecov YAML
+# https://docs.codecov.com/docs/codecov-yaml
+
+codecov:
+  branch: main
+
+coverage:
+  status:
+    project:
+      default:
+        informational: true
+    patch:
+      default:
+        informational: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,4 +16,21 @@ jobs:
       - uses: actions/setup-python@v5
       - uses: snok/install-poetry@v1
       - run: poetry install --with test
-      - run: poetry run pytest -vv
+      - run: poetry run pytest -vv --cov-report=xml:coverage.xml
+      - uses: actions/upload-artifact@v4
+        with:
+          name: coverage
+          path: "./coverage.xml"
+          if-no-files-found: error
+  codecov:
+    needs:
+      - test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/download-artifact@v4
+        with:
+          name: coverage
+      - uses: codecov/codecov-action@v4
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,6 +2,7 @@
 
 [![Pre-commit](https://img.shields.io/github/actions/workflow/status/paduszyk/reactor/pre-commit-run.yml?style=flat-square&logo=pre-commit&label=pre-commit)][pre-commit]
 [![Tests](https://img.shields.io/github/actions/workflow/status/paduszyk/reactor/test.yml?style=flat-square&logo=github&label=tests)][tests]
+[![Codecov](https://img.shields.io/codecov/c/github/paduszyk/reactor?style=flat-square&logo=codecov)][codecov]
 
 [![Poetry](https://img.shields.io/endpoint?url=https://python-poetry.org/badge/v0.json&style=flat-square)][poetry]
 [![Ruff](https://img.shields.io/endpoint?style=flat-square&url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)][ruff]
@@ -16,6 +17,7 @@ Created and maintained by Kamil Paduszyński ([@paduszyk][paduszyk]).
 
 Released under the [BSD 3-Clause License][license].
 
+[codecov]: https://app.codecov.io/gh/paduszyk/reactor
 [conventional-commits]: https://www.conventionalcommits.org/en/v1.0.0/
 [license]: https://github.com/paduszyk/reactor/blob/main/LICENSE
 [paduszyk]: https://github.com/paduszyk


### PR DESCRIPTION
Uploading the coverage reports to [Codecov](https://codecov.io) is set up to follow the successful run of tests (#7).